### PR TITLE
remove clutter from main directory and provide hint for looking at compilation errors

### DIFF
--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -511,23 +511,27 @@ prepare <- function() {
   # Merge GAMS files
   message("\nCreating full.gms")
 
-  # only compile the GAMS file to catch compilation errors and create a dump file with the full code
+  # only compile the GAMS file to catch compilation errors and create a dump
+  # file with the full code
   modelFilePathStem <- substr(tmpModelFile, 1, nchar(tmpModelFile) - 4)
   dumpFilePath <- paste0(modelFilePathStem, ".dmp")
   listFilePath <- paste0(modelFilePathStem, ".lst")
   logFilePath <- paste0(modelFilePathStem, ".log")
 
-  exitcode <- system2(cfg$gamsv, c(tmpModelFile, "action=c", "dumpopt=21", "logoption=", cfg$logoption))
-  if ( 0 < exitcode ) {
-    stop(paste("Compiling", tmpModelFile, "failed, stopping. Check",
-               logFilePath, ",", dumpFilePath, ", and", listFilePath, "for details." ))
-  }
-
+  exitcode <- system2(cfg$gamsv, c(tmpModelFile, "action=c", "dumpopt=21",
+                                   "logoption=", cfg$logoption))
   file.rename(dumpFilePath, file.path(cfg$results_folder, "full.gms"))
   file.rename(listFilePath, file.path(cfg$results_folder, "main.lst"))
   file.rename(tmpModelFile, file.path(cfg$results_folder, "main.gms"))
   if ( file.exists(logFilePath) ) {
     file.rename(logFilePath, file.path(cfg$results_folder, "main.log"))
+  }
+
+  if ( 0 < exitcode ) {
+      stop("Compiling ", tmpModelFile, " failed, stopping.", "\n",
+           "Use `less -j 4 --pattern='^\\*\\*\\*\\*' ",
+           file.path(cfg$results_folder, "main.lst"), "` to investigate ",
+           "compilation errors.")
   }
 
   # Collect run statistics (will be saved to central database in submit.R)

--- a/scripts/start/prepare_and_run.R
+++ b/scripts/start/prepare_and_run.R
@@ -520,12 +520,22 @@ prepare <- function() {
 
   exitcode <- system2(cfg$gamsv, c(tmpModelFile, "action=c", "dumpopt=21",
                                    "logoption=", cfg$logoption))
-  file.rename(dumpFilePath, file.path(cfg$results_folder, "full.gms"))
-  file.rename(listFilePath, file.path(cfg$results_folder, "main.lst"))
-  file.rename(tmpModelFile, file.path(cfg$results_folder, "main.gms"))
-  if ( file.exists(logFilePath) ) {
-    file.rename(logFilePath, file.path(cfg$results_folder, "main.log"))
+
+  # move compilation files to results directory and rename appropriately, but
+  # only if they exist.
+  from <- c(dumpFilePath, listFilePath, tmpModelFile, logFilePath)
+  to <- file.path(cfg$results_folder, c('full.gms', 'main.lst', 'main.gms',
+                                        'main.log'))
+  exist <- file.exists(from)
+  # if any of the files main.dmp, main.lst, or main.gms is missing, panic!
+  # (honestly, no idea how that could happen, but you never know)
+  if (!all(exist[1:3])) {
+      stop('Something went horribly wrong, the files ',
+           paste(from[which(!exist[1:3])], collapse = ', '),
+           ' are missing.  Call RSE immediately')
   }
+
+  file.rename(from[exist], to[exist])
 
   if ( 0 < exitcode ) {
       stop("Compiling ", tmpModelFile, " failed, stopping.", "\n",


### PR DESCRIPTION
There's no point for files belonging to a run that has an output directory to loiter in the main directory.

Output looks like this:
```
Creating full.gms
Error in prepare() : Compiling main_testOneRegi.gms failed, stopping.
Use `less -j 4 --pattern='^\*\*\*\*' output/testOneRegi/main.lst` to investigate compilation errors.
2022-11-30 15:16:04: unlocked model.
Execution halted


Finished: 1 runs started. 0 runs are waiting. 
```