### PR TITLE
Add sbatch option "--wait" to scenario_config_coupled_shortCascade.cs…

### DIFF
--- a/config/tests/scenario_config_coupled_shortCascade.csv
+++ b/config/tests/scenario_config_coupled_shortCascade.csv
@@ -1,3 +1,3 @@
-title;start;qos;magpie_scen;no_ghgprices_land_until;max_iterations;oldrun;path_gdx;path_gdx_ref;path_gdx_bau;path_report
-SSP2EU-Base;1;priority;SSP2|NPI;y2150;2;;;;;
-SSP2EU-NDC;1;priority;SSP2|NDC;y2150;2;;;;;
+title;start;qos;sbatch;magpie_scen;no_ghgprices_land_until;max_iterations;oldrun;path_gdx;path_gdx_ref;path_gdx_bau;path_report
+SSP2EU-Base;1;priority;--wait;SSP2|NPI;y2150;2;;;;;
+SSP2EU-NDC;1;priority;--wait;SSP2|NDC;y2150;2;;;;;

--- a/config/tests/scenario_config_shortCascade.csv
+++ b/config/tests/scenario_config_shortCascade.csv
@@ -1,3 +1,3 @@
-title;start;c_empty_model;slurmConfig;path_gdx_ref;path_gdx_bau
-SSP2EU-Base;1;on;settings given here need to be respected by start_coupled.R:L297 and start_bundle_coupled.R:L526;;
-SSP2EU-NDC;1;on;settings given here need to be respected by start_coupled.R:L297 and start_bundle_coupled.R:L526;SSP2EU-Base;SSP2EU-Base
+title;start;c_empty_model;path_gdx_ref;path_gdx_bau
+SSP2EU-Base;1;on;;
+SSP2EU-NDC;1;on;SSP2EU-Base;SSP2EU-Base

--- a/scripts/start/readCheckScenarioConfig.R
+++ b/scripts/start/readCheckScenarioConfig.R
@@ -45,7 +45,7 @@ readCheckScenarioConfig <- function(filename, remindPath = ".", testmode = FALSE
                         "results_folder", "force_replace", "action")
   if (grepl("scenario_config_coupled", filename)) {
     knownColumnNames <- c(knownColumnNames, "cm_nash_autoconverge_lastrun", "oldrun", "path_report", "magpie_scen",
-                          "no_ghgprices_land_until", "qos", "path_mif_ghgprice_land", "max_iterations")
+                          "no_ghgprices_land_until", "qos", "sbatch", "path_mif_ghgprice_land", "max_iterations")
   }
   unknownColumnNames <- names(scenConf)[! names(scenConf) %in% knownColumnNames]
   if (length(unknownColumnNames) > 0) {

--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -225,6 +225,8 @@ for(scen in common){
   path_report  <- NULL                                   # sets the path to the report REMIND is started with in the first loop
   qos          <- scenarios_coupled[scen, "qos"]         # set the SLURM quality of service (priority/short/medium/...)
   if(is.null(qos) | is.na(qos)) qos <- "short"           # if qos could not be found in scenarios_coupled use short/medium
+  sbatch       <- scenarios_coupled[scen, "sbatch"]      # retrieve sbatch options from scenarios_coupled
+  if (is.null(sbatch) | is.na(sbatch)) sbatch <- ""       # if sbatch could not be found in scenarios_coupled use empty string
   start_iter_first <- 1                                  # iteration to start the coupling with
 
   # Check for existing REMIND and MAgPIE runs and whether iteration can be continued from those (at least one REMIND iteration has to exist!)
@@ -496,9 +498,11 @@ for(scen in common){
         logfile <- file.path("output", fullrunname, paste0("log", if (start_magpie) "-mag", ".txt"))
         if (! file.exists(dirname(logfile))) dir.create(dirname(logfile))
         message("Find logging in ", logfile)
-        system(paste0("sbatch --qos=", qos, " --job-name=", fullrunname,
+        slurm_command <- paste0("sbatch --qos=", qos, " --job-name=", fullrunname,
         " --output=", logfile, " --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", nr_of_regions,
-        " --wrap=\"Rscript start_coupled.R coupled_config=", Rdatafile, "\""))
+        " ", sbatch, " --wrap=\"Rscript start_coupled.R coupled_config=", Rdatafile, "\"")
+        message(slurm_command)
+        system(slurm_command)
       }
     }
   } else {

--- a/start_coupled.R
+++ b/start_coupled.R
@@ -295,7 +295,7 @@ start_coupled <- function(path_remind, path_magpie, cfg_rem, cfg_mag, runname, m
         if (! file.exists(dirname(logfile))) dir.create(dirname(logfile))
         subsequentcommand <- paste0("sbatch --qos=", subseq.env$qos, " --job-name=", subseq.env$fullrunname, " --output=", logfile,
         " --mail-type=END --comment=REMIND-MAgPIE --tasks-per-node=", nr_of_regions,
-        " --wrap=\"Rscript start_coupled.R coupled_config=", RData_file, "\"")
+        " ", subseq.env$sbatch, " --wrap=\"Rscript start_coupled.R coupled_config=", RData_file, "\"")
         message(subsequentcommand)
         if (length(needfulldatagdx) > 0) {
           system(subsequentcommand)


### PR DESCRIPTION
…v and get the option included in the sbatch commands of the coupling scripts.

# Purpose of this PR

For the new tests that will test the coupled system: introduce sbatch option "--wait" to let the test script wait until the slurm job it started finishes and then perform the tests.

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [ ] Bug fix 
- [ ] Refactoring
- [x] New feature 
- [ ] Minor change (default scenarios show only small differences)
- [ ] Fundamental change
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the coding etiquette
- [x] I have performed a self-review of my own code
- [x] Changes are commented, particularly in hard-to-understand areas
- [ ] I have updated the in-code documentation
- [ ] I have adjusted reporting where it was needed
- [ ] All automated model tests pass (`FAIL 0` in the output of `make test`)
