### PR TITLE
avoid three capital letter or 'glob' scenario titles

### DIFF
--- a/tests/testthat/test_01-readCheckScenarioConfig.R
+++ b/tests/testthat/test_01-readCheckScenarioConfig.R
@@ -9,12 +9,15 @@ for (csvfile in csvfiles) {
 test_that("readCheckScenarioConfig fails on error-loaden config", {
   csvfile <- tempfile(pattern = "scenario_config_a", fileext = ".csv")
   writeLines(c(";start;c_budgetCO2",
-               "abc.loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33"),
+               "abc.loremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsumloremipsum_;0;33",
+               "PBS;1;29",
+               "glob;0;33"),
              con = csvfile, sep = "\n")
   w <- capture_warnings(expect_error(readCheckScenarioConfig(csvfile, remindPath = "../../", testmode = TRUE),
-                                     "4 errors found"))
+                                     "6 errors found"))
   expect_match(w, "These titles are too long", all = FALSE)
-  expect_match(w, "These titles contain dots", all = FALSE)
+  expect_match(w, "These titles may be confused with regions", all = FALSE)
+  expect_match(w, "These titles contain a dot", all = FALSE)
   expect_match(w, "These titles end with _", all = FALSE)
   expect_match(w, "Outdated column names found that must not be used", all = FALSE)
 })


### PR DESCRIPTION
## Purpose of this PR

Ease restriction such that short scenario names can be used if they are not three capital letters, but exclude 'glob'