### PR TITLE
fix bug if sbatch, qos or magpie_empty are no columns in coupled config

### DIFF
--- a/start_bundle_coupled.R
+++ b/start_bundle_coupled.R
@@ -235,12 +235,12 @@ for(scen in common){
   runname      <- paste0(prefix_runname, scen)            # name of the run that is used for the folder names
   path_report  <- NULL                                    # sets the path to the report REMIND is started with in the first loop
   qos          <- scenarios_coupled[scen, "qos"]          # set the SLURM quality of service (priority/short/medium/...)
-  if(is.null(qos) | is.na(qos)) qos <- "short"            # if qos could not be found in scenarios_coupled use short/medium
+  if(is.null(qos) || is.na(qos)) qos <- "short"           # if qos could not be found in scenarios_coupled use short/medium
   sbatch       <- scenarios_coupled[scen, "sbatch"]       # retrieve sbatch options from scenarios_coupled
-  if (is.null(sbatch) | is.na(sbatch)) sbatch <- ""       # if sbatch could not be found in scenarios_coupled use empty string
+  if (is.null(sbatch) || is.na(sbatch)) sbatch <- ""      # if sbatch could not be found in scenarios_coupled use empty string
   start_iter_first <- 1                                   # iteration to start the coupling with
   magpie_empty <- scenarios_coupled[scen, "magpie_empty"] # if magpie should be replaced by an empty model
-  if (is.null(magpie_empty) | is.na(magpie_empty)) magpie_empty <- FALSE
+  if (is.null(magpie_empty) || is.na(magpie_empty)) magpie_empty <- FALSE
 
   # Check for existing REMIND and MAgPIE runs and whether iteration can be continued from those (at least one REMIND iteration has to exist!)
   # Look whether there is already a fulldata.gdx from a former REMIND run (check for old name if provided)


### PR DESCRIPTION
## Purpose of this PR

- bugfix: if sbatch, qos or magpie_empty are no columns in coupled config, then `is.na(sbatch)` fails with `! argument is of length zero`.